### PR TITLE
Fix cascade delete

### DIFF
--- a/jupyterhub_entrypoint/dbi/__init__.py
+++ b/jupyterhub_entrypoint/dbi/__init__.py
@@ -37,6 +37,9 @@ def async_engine(*args, **kwargs):
 
 def register_foreign_keys(): # pragma: no cover
     """Enable deletes with cascade in e.g. sqlite"""
+
+    # See https://docs.sqlalchemy.org/en/14/dialects/sqlite.html?highlight=pragma#foreign-key-support
+
     @event.listens_for(Engine, "connect")
     def connect(dbi_connection, connection_record):
         cursor = dbi_connection.cursor()

--- a/tests/dbi/entrypoints/test_delete.py
+++ b/tests/dbi/entrypoints/test_delete.py
@@ -48,9 +48,19 @@ async def test_cascade(engine, context_names, entrypoint_args):
             if args[-1]:
                 await dbi.create_entrypoint(conn, *args)
                 break
+
+    async with engine.begin() as conn:
+        statement = select(dbi.model.entrypoints)
+        results = await conn.execute(statement)
+        assert len(list(results)) == 1
     
     async with engine.begin() as conn:
         await dbi.delete_entrypoint(conn, *args[:2])
+
+    async with engine.begin() as conn:
+        statement = select(dbi.model.entrypoints)
+        results = await conn.execute(statement)
+        assert len(list(results)) == 0
 
     async with engine.begin() as conn:
         statement = select(dbi.model.entrypoint_contexts)


### PR DESCRIPTION
SQLite supports FOREIGN KEY syntax when emitting CREATE statements for tables, however by default these constraints have no effect on the operation of the table.  See:

https://docs.sqlalchemy.org/en/14/dialects/sqlite.html?highlight=pragma#foreign-key-support

e.g. https://stackoverflow.com/a/57726586

Added a test to make sure delete entrypoint cascades to tags.