### PR TITLE
Entrypoint guid

### DIFF
--- a/jupyterhub_entrypoint/dbi/__init__.py
+++ b/jupyterhub_entrypoint/dbi/__init__.py
@@ -12,6 +12,7 @@ from .entrypoints import (
     retrieve_one_entrypoint,
     retrieve_many_entrypoints,
     update_entrypoint,
+    update_entrypoint_uuid,
     tag_entrypoint,
     untag_entrypoint,
     delete_entrypoint

--- a/jupyterhub_entrypoint/dbi/entrypoints.py
+++ b/jupyterhub_entrypoint/dbi/entrypoints.py
@@ -1,5 +1,6 @@
 
 import itertools
+from uuid import uuid4
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import insert, select, update, delete
@@ -39,6 +40,7 @@ async def create_entrypoint(
         insert(entrypoints)
         .values(
             user=user,
+            uuid=str(uuid4()),
             entrypoint_name=entrypoint_name,
             entrypoint_type=entrypoint_type,
             entrypoint_data=entrypoint_data

--- a/jupyterhub_entrypoint/dbi/entrypoints.py
+++ b/jupyterhub_entrypoint/dbi/entrypoints.py
@@ -270,6 +270,45 @@ async def update_entrypoint(
     if results.rowcount == 0:
         raise ValueError
 
+async def update_entrypoint_uuid(
+    conn,
+    user,
+    uuid,
+    entrypoint_name,
+    entrypoint_data
+):
+    """Update the user entrypoint with the given UUID.
+
+    This makes it possible to change the entrypoint type or entrypoint data.
+    Both must be supplied even if they are not being changed.
+
+    Args:
+        conn            (AsyncConnection): SQLAlchemy asyncio connection proxy
+        user            (str): User name
+        uuid            (str): Service-assigned UUID
+        entrypoint_name (str): User-assigned entrypoint name
+        entrypoint_data (dict): Type-specific metadata
+
+    Raises:
+        ValueError: If the entrypoint to update cannot be found.
+
+    """
+
+    statement = (
+        update(entrypoints)
+        .where(
+            entrypoints.c.user == user,
+            entrypoints.c.uuid == uuid
+        )
+        .values(
+           entrypoint_name=entrypoint_name,
+           entrypoint_data=entrypoint_data
+        )
+    )
+    results = await conn.execute(statement)
+    if results.rowcount == 0:
+        raise ValueError
+
 async def _entrypoint_context_ids(conn, user, entrypoint_name, context_name):
     """Utility function for tag/untag entrypoint operations"""
 

--- a/jupyterhub_entrypoint/dbi/entrypoints.py
+++ b/jupyterhub_entrypoint/dbi/entrypoints.py
@@ -218,6 +218,7 @@ async def retrieve_many_entrypoints(
         grouper = itertools.groupby(rows, lambda r: r.entrypoint_type)
         data[context_name] = dict((
             entrypoint_type, [{
+                "uuid": r.uuid,
                 "entrypoint_data": r.entrypoint_data,
                 "selected": r.selected
             } for r in rows]

--- a/jupyterhub_entrypoint/dbi/model.py
+++ b/jupyterhub_entrypoint/dbi/model.py
@@ -1,6 +1,7 @@
 
 from sqlalchemy import (
-    Column, ForeignKey, Integer, JSON, MetaData, Table, Text, UniqueConstraint
+    Column, ForeignKey, Integer, JSON, MetaData,
+    String, Table, Text, UniqueConstraint
 )
 
 metadata = MetaData()
@@ -16,6 +17,7 @@ entrypoints = Table(
     "entrypoints",
     metadata,
     Column("id", Integer, primary_key=True),
+    Column("uuid", String(36), nullable=False, unique=True),
     Column("user", Text, nullable=False),
     Column("entrypoint_name", Text, nullable=False),
     Column("entrypoint_type", Text, nullable=False),

--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -173,7 +173,7 @@ class UpdateHandler(WebHandler):
         self.template_manage = self.env.get_template("manage.html")
 
     @authenticated
-    async def get(self, entrypoint_name):
+    async def get(self, uuid):
 
         context_name = self.get_query_argument("context")
 
@@ -184,7 +184,7 @@ class UpdateHandler(WebHandler):
 
         async with self.engine.begin() as conn:
             result = await dbi.retrieve_one_entrypoint(
-                conn, username, entrypoint_name
+                conn, username, uuid=uuid
             )
         entrypoint_data = result["entrypoint_data"]
         context_names = result["context_names"]
@@ -206,7 +206,8 @@ class UpdateHandler(WebHandler):
             context_name=context_name,
             checked_context_names=context_names,
             contexts=self.settings["contexts"],
-            entrypoint_data=entrypoint_data
+            entrypoint_data=entrypoint_data,
+            uuid=uuid
         )
         self.write(chunk)
 

--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -311,64 +311,6 @@ class EntrypointAPIHandler(EntrypointHandler):
             self.log.error(f"Error ({e}): {entrypoint_data}")
             self.write({"result": False, "message": "Error"})
 
-#   @authenticated
-#   async def put(self, entrypoint_name):
-#       """TBD"""
-
-#       user = self.get_current_user().get("name")
-
-#       async with self.engine.begin() as conn:
-#           result = await dbi.retrieve_one_entrypoint(
-#               conn, user, entrypoint_name
-#           )
-#       current_context_names = result["context_names"]
-
-#       try:
-#           payload = json_decode(self.request.body)
-#           entrypoint_data = payload["entrypoint_data"]
-#           await self.validate_entrypoint_data(user, entrypoint_data)
-#           context_names = payload["context_names"] or self.context_names
-#           self.validate_context_names(context_names)
-#           to_tag = list(
-#               set(context_names).difference(
-#                   set(current_context_names)
-#               )
-#           )
-#           to_untag = list(
-#               set(current_context_names).difference(
-#                   set(context_names)
-#               )
-#           )
-#           async with self.engine.begin() as conn:
-#               await dbi.update_entrypoint(
-#                   conn,
-#                   user,
-#                   entrypoint_data["entrypoint_name"],
-#                   entrypoint_data["entrypoint_type"],
-#                   entrypoint_data
-#               )
-#               for context_name in to_tag:
-#                   await dbi.tag_entrypoint(
-#                       conn,
-#                       user,
-#                       entrypoint_data["entrypoint_name"],
-#                       context_name
-#                   )
-#               for context_name in to_untag:
-#                   await dbi.untag_entrypoint(
-#                       conn,
-#                       user,
-#                       entrypoint_data["entrypoint_name"],
-#                       context_name
-#                   )
-#           self.write({"result": True, "message": "Entrypoint updated"})
-#       except EntrypointValidationError:
-#           self.log.error(f"Validation error: {entrypoint_data}")
-#           self.write({"result": False, "message": "Validation error"})
-#       except Exception as e:
-#           self.log.error(f"Error ({e}): {entrypoint_data}")
-#           self.write({"result": False, "message": "Error"})
-
     async def validate_entrypoint_data(self, user, entrypoint_data):
         """Validate request and run appropriate validator on entrypoint data.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@
           {{entrypoint.entrypoint_data.entrypoint_name}}
         </label>
         <span class="pull-right">
-          <a class="btn btn-primary btn-sm" href="{{service_prefix}}entrypoints/{{entrypoint.entrypoint_data.entrypoint_name}}?context={{context_name}}" type="button">
+          <a class="btn btn-primary btn-sm" href="{{service_prefix}}entrypoints/{{entrypoint.uuid}}?context={{context_name}}" type="button">
             update
           </a>
           <button type="button" onclick="deleteEntrypoint('{{entrypoint.entrypoint_data.entrypoint_name}}')" class="btn btn-danger btn-sm">

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -157,7 +157,7 @@ async function updateEntrypoint(entrypoint_data, context_names) {
     const entrypoint_name = payload.entrypoint_data.entrypoint_name;
     const response = await $.ajax({
         method: "PUT",
-        url: `/services/entrypoint/api/entrypoints/${entrypoint_name}`,
+        url: "/services/entrypoint/api/entrypoints/{{uuid}}",
         data: JSON.stringify(payload),
         contentType: "application/json; charset=utf-8",
         dataType: "json",

--- a/tests/dbi/entrypoints/test_create.py
+++ b/tests/dbi/entrypoints/test_create.py
@@ -1,5 +1,6 @@
 
 import pytest
+from sqlalchemy.sql import select
 
 from jupyterhub_entrypoint import dbi
 
@@ -14,6 +15,13 @@ async def test_ok(engine, context_names, entrypoint_args):
     async with engine.begin() as conn:
         for args in entrypoint_args:
             await dbi.create_entrypoint(conn, *args)
+
+    # See if records were created, real basic...
+
+    statement = select(dbi.model.entrypoints)
+    async with engine.begin() as conn:
+        results = await conn.execute(statement)
+    assert len(list(results)) == len(entrypoint_args)
 
 @pytest.mark.asyncio
 async def test_contexts_ok(engine, context_names, entrypoint_args):

--- a/tests/dbi/entrypoints/test_retrieve_many.py
+++ b/tests/dbi/entrypoints/test_retrieve_many.py
@@ -28,6 +28,7 @@ async def test_all_ok(engine, context_names, entrypoint_args, users):
                 x["entrypoint_data"]["user"] == user and 
                 x["entrypoint_data"]["entrypoint_name"] == entrypoint_name and
                 x["entrypoint_data"]["entrypoint_type"] == entrypoint_type and
+                "uuid" in x and
                 all([x["entrypoint_data"][key] == data[key] for key in data])
             ), False)
 

--- a/tests/dbi/entrypoints/test_retrieve_one.py
+++ b/tests/dbi/entrypoints/test_retrieve_one.py
@@ -1,5 +1,6 @@
 
 import pytest
+from sqlalchemy.sql import select
 
 from jupyterhub_entrypoint import dbi
 
@@ -28,6 +29,83 @@ async def test_ok(engine, context_names, entrypoint_args):
     assert len(output_context_names) == len(args[4])
     for output_context_name, expected_context_name in zip(output_context_names, args[4]):
         assert output_context_name == expected_context_name
+
+@pytest.mark.asyncio
+async def test_name_xor_uuid(engine, context_names, entrypoint_args):
+    async with engine.begin() as conn:
+        for context_name in context_names:
+            await dbi.create_context(conn, context_name)
+    async with engine.begin() as conn:
+        for args in entrypoint_args:
+            await dbi.create_entrypoint(conn, *args)
+
+    # UUIDs are created on insert, so try to grab
+
+    statement = select(
+        dbi.model.entrypoints.c.user,
+        dbi.model.entrypoints.c.entrypoint_name,
+        dbi.model.entrypoints.c.uuid
+    )
+    async with engine.begin() as conn:
+        results = await conn.execute(statement)
+    user, entrypoint_name, uuid = results.first()
+
+    # No entrypoint or UUID should fail
+
+    with pytest.raises(ValueError):
+        async with engine.begin() as conn:
+            output = await dbi.retrieve_one_entrypoint(conn, user)
+
+    # Both entrypoint name and UUID should fail
+
+    with pytest.raises(ValueError):
+        async with engine.begin() as conn:
+            output = await dbi.retrieve_one_entrypoint(conn, user, entrypoint_name, uuid)
+     
+    # Just entrypoint name should succeed
+
+    async with engine.begin() as conn:
+        output = await dbi.retrieve_one_entrypoint(conn, user, entrypoint_name)
+        assert len(output) == 2
+        assert "entrypoint_data" in output
+        assert "context_names" in output
+        assert output["entrypoint_data"]["user"] == user
+        assert output["entrypoint_data"]["entrypoint_name"] == entrypoint_name
+
+    # Just UUID should succeed
+
+    async with engine.begin() as conn:
+        output = await dbi.retrieve_one_entrypoint(conn, user, uuid=uuid)
+        assert len(output) == 2
+        assert "entrypoint_data" in output
+        assert "context_names" in output
+        assert output["entrypoint_data"]["user"] == user
+        assert output["entrypoint_data"]["entrypoint_name"] == entrypoint_name
+
+@pytest.mark.asyncio
+async def test_uuid(engine, context_names, entrypoint_args):
+    async with engine.begin() as conn:
+        for context_name in context_names:
+            await dbi.create_context(conn, context_name)
+    async with engine.begin() as conn:
+        for args in entrypoint_args:
+            await dbi.create_entrypoint(conn, *args)
+
+    # UUIDs are created on insert, so try to grab
+
+    statement = select(
+        dbi.model.entrypoints.c.user,
+        dbi.model.entrypoints.c.uuid
+    )
+    async with engine.begin() as conn:
+        results = await conn.execute(statement)
+        for result in results:
+            user, uuid = result
+            output = await dbi.retrieve_one_entrypoint(conn, user, uuid=uuid)
+            assert len(output) == 2
+            assert "entrypoint_data" in output
+            assert "context_names" in output
+            assert output["entrypoint_data"]["user"] == user
 
 @pytest.mark.asyncio
 async def test_fails(engine, context_names, entrypoint_args):


### PR DESCRIPTION
This adds a UUID field to the entrypoint table that is populated on insert and remains unchanged for the lifetime of the entrypoint.  Why:
- This UUID is added so that we can allow users to change the name of an entrypoint if they want and,
- Keeps user-defined entrypoint names from appearing in URLs
- Allows users maybe a little more freedom in how they name them (spaces, etc)
We had this before in the file-based schema but took it out.  We should have kept it for the above reasons.  This still needs testing, which I will add shortly, but this was ready to push so I went ahead.

Functionality wise no real changes except now changing an entrypoint name works (as long as the user has no other entrypoint with the same name).  This is enough in my opinion to have @shreddd take a look.