### PR TITLE
Streamline entrypoint data schema

### DIFF
--- a/jupyterhub_entrypoint/dbi/entrypoints.py
+++ b/jupyterhub_entrypoint/dbi/entrypoints.py
@@ -93,6 +93,7 @@ async def retrieve_one_entrypoint(conn, user, entrypoint_name=None, uuid=None):
 
     statement = (
         select(
+            entrypoints.c.entrypoint_type,
             entrypoints.c.entrypoint_data,
             contexts.c.context_name
         )
@@ -129,6 +130,7 @@ async def retrieve_one_entrypoint(conn, user, entrypoint_name=None, uuid=None):
     entrypoint_data = dict()
     context_names = list()
     for r in results.fetchall():
+        entrypoint_type = r.entrypoint_type
         entrypoint_data = r.entrypoint_data
         context_names.append(r.context_name)
     if len(context_names) == 1 and context_names[0] is None:
@@ -137,7 +139,11 @@ async def retrieve_one_entrypoint(conn, user, entrypoint_name=None, uuid=None):
     if not entrypoint_data:
         raise ValueError
 
-    return dict(entrypoint_data=entrypoint_data, context_names=context_names)
+    return dict(
+        entrypoint_type_name=entrypoint_type,
+        entrypoint_data=entrypoint_data,
+        context_names=context_names
+    )
 
 async def retrieve_many_entrypoints(
     conn,

--- a/jupyterhub_entrypoint/dbi/entrypoints.py
+++ b/jupyterhub_entrypoint/dbi/entrypoints.py
@@ -84,7 +84,7 @@ async def retrieve_one_entrypoint(conn, user, entrypoint_name=None, uuid=None):
         uuid            (str, optional): Service-assigned UUID
 
     Returns:
-        dict: Contains entrypoint data and list of context names
+        dict: Contains entrypoint type, data, and list of context names
 
     Raises:
         ValueError: If no entrypoint named `entrypoint_name` is found.

--- a/jupyterhub_entrypoint/dbi/selections.py
+++ b/jupyterhub_entrypoint/dbi/selections.py
@@ -85,7 +85,10 @@ async def retrieve_selection(conn, user, context_name):
         context_name    (str): Context used to find selection
 
     Returns:
-        dict: User entrypoint data
+        (tuple): tuple containing:
+
+            str: Entrypoint type
+            dict: User entrypoint data
 
     Raises:
         ValueError: If no selection is found.
@@ -94,6 +97,7 @@ async def retrieve_selection(conn, user, context_name):
 
     statement = (
         select(
+            entrypoints.c.entrypoint_type,
             entrypoints.c.entrypoint_data,
         )
         .select_from(entrypoints)
@@ -109,7 +113,7 @@ async def retrieve_selection(conn, user, context_name):
     if not result:
         raise ValueError
 
-    return result.entrypoint_data
+    return (result.entrypoint_type, result.entrypoint_data)
 
 async def delete_selection(conn, user, context_name):
     """Delete user entrypoint selection for the given context name.

--- a/jupyterhub_entrypoint/types.py
+++ b/jupyterhub_entrypoint/types.py
@@ -58,12 +58,10 @@ class EntrypointType:
         self.schema = {
             "type": "object",
             "properties": {
-                "user": {"type": "string"},
-                "entrypoint_name": {"type": "string", "pattern": "^[a-z0-9.\-_]+$"},
-                "entrypoint_type": {"type": "string"},
+                "entrypoint_name": {"type": "string"},
             },
             "required": [
-                "user", "entrypoint_name", "entrypoint_type"
+                "entrypoint_name"
             ]
         }
 
@@ -164,8 +162,6 @@ class EntrypointType:
 
         """
 
-        if name in ["user", "entrypoint_type"]:
-            return ""
         prop = self.schema["properties"][name]
         options = await self.get_options(name, prop)
         if options:

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -71,11 +71,8 @@
 
 async function addHandler() {
 
-    let entrypoint_data = {
-        user: "{{user.name}}",
-        entrypoint_type: "{{entrypoint_type.type_name}}",
-    };
-
+    let entrypoint_type = "{{entrypoint_type.type_name}}";
+    let entrypoint_data = {};
     let context_names = [];
 
     $("#form :input").each(function(index) {
@@ -89,7 +86,7 @@ async function addHandler() {
         }
     });
 
-    result = await addEntrypoint(entrypoint_data, context_names);
+    result = await addEntrypoint(entrypoint_type, entrypoint_data, context_names);
 
     if (!result.result) {
         $("#error-msg").html(`<div class="alert alert-danger" role="alert">${result.message}</div>`);
@@ -102,8 +99,9 @@ async function addHandler() {
 
 // Add user entrypoint
 
-async function addEntrypoint(entrypoint_data, context_names) {
+async function addEntrypoint(entrypoint_type, entrypoint_data, context_names) {
     const payload = {
+        entrypoint_type: entrypoint_type,
         entrypoint_data: entrypoint_data,
         context_names: context_names
     };
@@ -120,11 +118,7 @@ async function addEntrypoint(entrypoint_data, context_names) {
 
 async function updateHandler() {
 
-    let entrypoint_data = {
-        user: "{{user.name}}",
-        entrypoint_type: "{{entrypoint_type.type_name}}",
-    };
-
+    let entrypoint_data = {};
     let context_names = [];
 
     $("#form :input").each(function(index) {

--- a/tests/dbi/selections/test_retrieve.py
+++ b/tests/dbi/selections/test_retrieve.py
@@ -26,9 +26,10 @@ async def test_ok(engine, context_names, entrypoint_args):
 
     async with engine.begin() as conn:
         output_data = await dbi.retrieve_selection(conn, user, context_names[1])
-    assert len(output_data) == len(args[-2])
+    entrypoint_type_name, entrypoint_data = output_data
+    assert len(entrypoint_data) == len(args[-2])
     for key in args[-2]:
-        assert output_data[key] == args[-2][key]
+        assert entrypoint_data[key] == args[-2][key]
 
 @pytest.mark.asyncio
 async def test_unknown(engine, context_names, entrypoint_args):


### PR DESCRIPTION
Removes user and entrypoint_type fields from the entrypoint_data model, there isn't a reason for it to be there.  This means that we need to rely on other things to tell us the type of an entrypoint, but these are readily available when the user sends the request or when we do a query of the database.  We also are removing the ability for an update to change the type of an entrypoint, which should not be possible.