### PR TITLE
Return spawner args

### DIFF
--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -402,10 +402,10 @@ class HubSelectionAPIHandler(BaseHandler):
         entrypoint_type_name, entrypoint_data = result
         entrypoint_type = self.entrypoint_types.get(entrypoint_type_name)
 
-        cmd = list()
+        spawner_args = dict()
         if isinstance(entrypoint_type, EntrypointType):
-            cmd = entrypoint_type.cmd(entrypoint_data)
-        self.write(dict(cmd=cmd))
+            spawner_args = entrypoint_type.spawner_args(entrypoint_data)
+        self.write(spawner_args)
 
     def validate_token(self):
         """TBD"""

--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -404,8 +404,22 @@ class HubSelectionAPIHandler(BaseHandler):
 
         spawner_args = dict()
         if isinstance(entrypoint_type, EntrypointType):
-            spawner_args = entrypoint_type.spawner_args(entrypoint_data)
+            kwargs = self.parse_query_arguments()
+            spawner_args = entrypoint_type.spawner_args(
+                entrypoint_data,
+                **kwargs
+            )
         self.write(spawner_args)
+
+    def parse_query_arguments(self):
+        """TBD"""
+
+        kwargs = dict()
+
+        batchspawner = self.get_query_argument("batchspawner", "false").lower()
+        kwargs["batchspawner"] = batchspawner in ["true", "yes", "1"]
+
+        return kwargs
 
     def validate_token(self):
         """TBD"""

--- a/jupyterhub_entrypoint/types.py
+++ b/jupyterhub_entrypoint/types.py
@@ -64,7 +64,6 @@ class EntrypointType:
                 "entrypoint_name"
             ]
         }
-        self.batchspawner = kwargs.get("batchspawner", True)
         self.executable = kwargs.get("executable", "jupyter-labhub")
 
     def extend_schema(self, properties):
@@ -268,7 +267,7 @@ class EntrypointType:
         except ValidationError:
             raise EntrypointValidationError
 
-    def spawner_args(self, entrypoint_data):
+    def spawner_args(self, entrypoint_data, **kwargs):
         """Convert entrypoint data into spawner arguments.
 
         This method returns entrypoint data verbatim by default, but can be
@@ -277,6 +276,7 @@ class EntrypointType:
 
         Args:
             entrypoint_data (dict): Entrypoint data
+            kwargs (dict): Query filters
 
         Returns:
             dict: Arguments like `cmd` used during Hub `start()`
@@ -405,20 +405,23 @@ class TrustedScriptEntrypointType(EntrypointType):
         super().__init__(**kwargs)
         self.extend_schema([{"script": {"type": "string", "enum": list(args)}}])
 
-    def spawner_args(self, entrypoint_data):
+    def spawner_args(self, entrypoint_data, **kwargs):
         """Convert entrypoint data into spawner arguments.
 
         Args:
             entrypoint_data (dict): Entrypoint data
+            kwargs (dict): Query filters
 
         Returns:
             dict: Arguments prefixed with the trusted entrypoint script
 
         """
 
+        batchspawner = kwargs.get("batchspawner", False)
+
         doc = dict()
         script = entrypoint_data["script"]
-        if self.batchspawner:
+        if batchspawner:
             doc["cmd"] = [self.executable]
             doc["batchspawner_singleuser_cmd"] = [
                 script,
@@ -473,20 +476,23 @@ class TrustedPathEntrypointType(EntrypointType):
         super().__init__(**kwargs)
         self.extend_schema([{"path": {"type": "string", "enum": list(args)}}])
 
-    def spawner_args(self, entrypoint_data):
+    def spawner_args(self, entrypoint_data, **kwargs):
         """Convert entrypoint data into spawner arguments.
 
         Args:
             entrypoint_data (dict): Entrypoint data
+            kwargs (dict): Query filters
 
         Returns:
             dict: Arguments prefixed with the trusted path
 
         """
 
+        batchspawner = kwargs.get("batchspawner", False)
+
         path = Path(entrypoint_data["path"])
         doc = dict(cmd=[str(path / self.executable)])
-        if self.batchspawner:
+        if batchspawner:
             doc["batchspawner_singleuser_cmd"] = [
                 str(path / "batchspawner-singleuser")
             ]
@@ -545,20 +551,23 @@ class ShifterEntrypointType(EntrypointType):
         )
         self.extend_schema([{"image": {"type": "string"}}])
 
-    def spawner_args(self, entrypoint_data):
+    def spawner_args(self, entrypoint_data, **kwargs):
         """Convert entrypoint data into spawner arguments.
 
         Args:
             entrypoint_data (dict): Entrypoint data
+            kwargs (dict): Query filters
 
         Returns:
             dict: Arguments prefixed with Shifter command and image
 
         """
 
+        batchspawner = kwargs.get("batchspawner", False)
+
         doc = dict()
         image = entrypoint_data["image"]
-        if self.batchspawner:
+        if batchspawner:
             doc["cmd"] = [self.executable]
             doc["batchspawner_singleuser_cmd"] = [
                 "shifter",


### PR DESCRIPTION
Modifies the hub selection endpoint so that it returns appropriate spawner arguments instead of just `cmd`.  Query parameters can be used to control formatting of the arguments, for instance if batchspawner is being used then `cmd` may need to be adjusted and `batchspawner_singleuser_cmd` set.