### PR TITLE
Make "about" message more customizable

### DIFF
--- a/example/entrypoint_config.py
+++ b/example/entrypoint_config.py
@@ -31,6 +31,21 @@
 #------------------------------------------------------------------------------
 ## This is an application.
 
+## Customizable explanation of the service.
+# c.EntrypointService.about_text = """\
+# <div class="row">
+#   <div class="col-md-offset-2 col-md-8">
+#     <hr>
+#     <h4>The JupyterHub Entrypoint Service</h4>
+#     <p>
+#       This service gives you a way to tell JupyterHub about what
+#       Jupyter environments you prefer to use most and also whether any
+#       one of those environments should be considered a default or
+#       favorite one in certain contexts.
+#     </p>
+#   </div>
+# </div>"""
+
 ## Config file to load
 #  Default: 'entrypoint_config.py'
 # c.EntrypointService.config_file = 'entrypoint_config.py'

--- a/jupyterhub_entrypoint/entrypoint.py
+++ b/jupyterhub_entrypoint/entrypoint.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import logging
 import os
 import sys
+from textwrap import dedent
 
 from jupyterhub.log import CoroutineLogFormatter
 from jupyterhub._data import DATA_FILES_PATH
@@ -145,6 +146,22 @@ class EntrypointService(config.Application):
         help="Turns on SQLAlchemy echo for verbose output"
     ).tag(config=True)
 
+    about_text = Unicode(dedent("""\
+        <div class="row">
+          <div class="col-md-offset-2 col-md-8">
+            <hr>
+            <h4>The JupyterHub Entrypoint Service</h4>
+            <p>
+              This service gives you a way to tell JupyterHub about what
+              Jupyter environments you prefer to use most and also whether any
+              one of those environments should be considered a default or
+              favorite one in certain contexts.
+            </p>
+          </div>
+        </div>"""),
+        help="Customizable explanation of the service."
+    ).tag(config=True)
+
     def initialize(self, argv=None):
         super().initialize(argv)
 
@@ -218,6 +235,7 @@ class EntrypointService(config.Application):
         # Configure handlers and launch Tornado app
 
         self.settings = {
+            "about_text": self.about_text,
             "cookie_secret": cookie_secret,
             "service_prefix": self.service_prefix,
             "entrypoint_api_token": self.entrypoint_api_token,

--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -54,6 +54,7 @@ class AboutHandler(WebHandler):
 
         super().initialize()
         self.template_about = self.env.get_template("about.html")
+        self.about_text = self.settings["about_text"]
 
     @authenticated
     async def get(self):
@@ -64,6 +65,7 @@ class AboutHandler(WebHandler):
         base_url = hub_auth.hub_prefix
 
         chunk = await self.template_about.render_async(
+            about_text=self.about_text,
             base_url=base_url,
             login_url=hub_auth.login_url,
             logout_url=url_path_join(base_url, "logout"),

--- a/templates/about.html
+++ b/templates/about.html
@@ -18,20 +18,7 @@
   </div>
 
   <!-- About -->
-  {% block about %}
-  <div class="row">
-    <div class="col-md-offset-2 col-md-8">
-      <hr>
-      <h4>The JupyterHub Entrypoint Service</h4>
-      <p>
-        This service gives you a way to tell JupyterHub about what Jupyter
-        environments you prefer to use most and also whether any one of those
-        environments should be considered a default or favorite one in certain
-        contexts.
-      </p>
-    </div>
-  </div>
-  {% endblock%}
+  {{ about_text }}
 
 </div>
 


### PR DESCRIPTION
Provides an easier option to customize the about template than
overriding it.

* Make `about_text` for AboutHandler configurable
* Use `about_text` contents in the template
* Change template to use `about_text` contents
* Update example entrypoint_config to include `about_text` traitlet