### PR TITLE
Defer type construction

### DIFF
--- a/examples/change-default/image-server.py
+++ b/examples/change-default/image-server.py
@@ -6,16 +6,16 @@ class ExampleImageHandler(RequestHandler):
 
     async def get(self, username):
         self.write({"images" : [
-            "ubuntu:latest",
-            "centos:latest",
-            "nginx:latest",
-            "redis:latest",
-            "node:latest",
-            "postgres:latest",
-            "mysql:latest",
-            "mongo:latest",
-            "debian:latest",
-            "jenkins:latest"
+            {"tag": ["ubuntu:latest"]},
+            {"tag": ["centos:latest"]},
+            {"tag": ["nginx:latest"]},
+            {"tag": ["redis:latest"]},
+            {"tag": ["node:latest"]},
+            {"tag": ["postgres:latest"]},
+            {"tag": ["mysql:latest"]},
+            {"tag": ["mongo:latest"]},
+            {"tag": ["debian:latest"]},
+            {"tag": ["jenkins:latest"]},
         ]})
 
 def main():

--- a/examples/change-default/image-server.py
+++ b/examples/change-default/image-server.py
@@ -4,7 +4,7 @@ from tornado.web import Application, RequestHandler
 
 class ExampleImageHandler(RequestHandler):
 
-    async def get(self):
+    async def get(self, username):
         self.write({"images" : [
             "ubuntu:latest",
             "centos:latest",
@@ -20,10 +20,10 @@ class ExampleImageHandler(RequestHandler):
 
 def main():
     app = Application([
-        ("/services/images/", ExampleImageHandler)
+        ("/services/images/list/(.+)", ExampleImageHandler)
     ])
     app.listen(8890, address="127.0.0.1")
-    IOLoop.current().start() 
+    IOLoop.current().start()
 
 if __name__ == "__main__":
     main()

--- a/examples/options-form/image-server.py
+++ b/examples/options-form/image-server.py
@@ -6,16 +6,16 @@ class ExampleImageHandler(RequestHandler):
 
     async def get(self, username):
         self.write({"images" : [
-            "ubuntu:latest",
-            "centos:latest",
-            "nginx:latest",
-            "redis:latest",
-            "node:latest",
-            "postgres:latest",
-            "mysql:latest",
-            "mongo:latest",
-            "debian:latest",
-            "jenkins:latest"
+            {"tag": ["ubuntu:latest"]},
+            {"tag": ["centos:latest"]},
+            {"tag": ["nginx:latest"]},
+            {"tag": ["redis:latest"]},
+            {"tag": ["node:latest"]},
+            {"tag": ["postgres:latest"]},
+            {"tag": ["mysql:latest"]},
+            {"tag": ["mongo:latest"]},
+            {"tag": ["debian:latest"]},
+            {"tag": ["jenkins:latest"]},
         ]})
 
 def main():

--- a/examples/options-form/image-server.py
+++ b/examples/options-form/image-server.py
@@ -4,7 +4,7 @@ from tornado.web import Application, RequestHandler
 
 class ExampleImageHandler(RequestHandler):
 
-    async def get(self):
+    async def get(self, username):
         self.write({"images" : [
             "ubuntu:latest",
             "centos:latest",
@@ -20,10 +20,10 @@ class ExampleImageHandler(RequestHandler):
 
 def main():
     app = Application([
-        ("/services/images/", ExampleImageHandler)
+        ("/services/images/list/(.+)", ExampleImageHandler)
     ])
     app.listen(8890, address="127.0.0.1")
-    IOLoop.current().start() 
+    IOLoop.current().start()
 
 if __name__ == "__main__":
     main()

--- a/jupyterhub_entrypoint/entrypoint.py
+++ b/jupyterhub_entrypoint/entrypoint.py
@@ -221,11 +221,10 @@ class EntrypointService(config.Application):
         coroutine = init_db(engine)
         loop.run_until_complete(coroutine)
 
-        # Create registry of entrypoint types
+        # Create registry of entrypoint type classes
 
         for cls, args in self.types:
-            entrypoint_type = cls(*args)
-            self.entrypoint_types[entrypoint_type.type_name] = entrypoint_type
+            self.entrypoint_types[cls.get_type_name()] = (cls, args)
 
         # Cookie secret
 

--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -333,7 +333,7 @@ class EntrypointAPIHandler(EntrypointHandler):
 
         """
 
-        FIXME: Actually check user
+        # FIXME: Actually check user
 
         try:
             cls, args = self.entrypoint_types[entrypoint_type_name]

--- a/jupyterhub_entrypoint/handlers.py
+++ b/jupyterhub_entrypoint/handlers.py
@@ -439,7 +439,7 @@ class HubSelectionAPIHandler(HubAPIHandler):
 
         try:
             cls, args = self.entrypoint_types[entrypoint_type_name]
-            entrypoint_type = cls(*args, user=username)
+            entrypoint_type = cls(*args, user=user)
         except KeyError:
             raise WebError(404)
 

--- a/jupyterhub_entrypoint/types.py
+++ b/jupyterhub_entrypoint/types.py
@@ -639,4 +639,6 @@ class ShifterEntrypointType(EntrypointType):
         )
         result = json_decode(response.body)
         images = result["images"]
-        return [image for image in images if self.image_filter(image)]
+        return [
+            image["tag"][0] for image in images if self.image_filter(image)
+        ]

--- a/jupyterhub_entrypoint/types.py
+++ b/jupyterhub_entrypoint/types.py
@@ -29,7 +29,7 @@ class EntrypointType:
     Subclass this and override the following methods:
 
     - spawner_args      default is to return entrypoint data verbatim
-    - get_type_name     optional, default is based on class name
+    - get_type_name     optional classmethod, default is based on class name
     - get_display_name  optional, default is get_type_name()
     - get_description   optional, default is empty string
     - get_options       optional, coroutine
@@ -286,7 +286,8 @@ class EntrypointType:
 
         return entrypoint_data
 
-    def get_type_name(self):
+    @classmethod
+    def get_type_name(cls):
         """Render the entrypoint type for use as a dict key.
 
         By default, an entrypoint type's class name is converted to a type name
@@ -303,7 +304,7 @@ class EntrypointType:
 
         """
 
-        return re.sub("EntrypointType$", "", self.__class__.__name__).lower()
+        return re.sub("EntrypointType$", "", cls.__name__).lower()
 
     def get_display_name(self):
         """Render the entrypoint type in a human-friendly string.
@@ -431,7 +432,8 @@ class TrustedScriptEntrypointType(EntrypointType):
             doc["cmd"] = [script, self.executable]
         return doc
 
-    def get_type_name(self):
+    @classmethod
+    def get_type_name(cls):
         """Override default type name behavior."""
         return "trusted_script"
 
@@ -498,7 +500,8 @@ class TrustedPathEntrypointType(EntrypointType):
             )
         return doc
 
-    def get_type_name(self):
+    @classmethod
+    def get_type_name(cls):
         """Override default type name behavior."""
         return "trusted_path"
 

--- a/jupyterhub_entrypoint/types.py
+++ b/jupyterhub_entrypoint/types.py
@@ -634,7 +634,7 @@ class ShifterEntrypointType(EntrypointType):
 
         client = AsyncHTTPClient()
         response = await client.fetch(
-            f"{self.shifter_api_url}/list/{self.username}",
+            f"{self.shifter_api_url}list/{self.username}",
             headers={"Authorization": self.shifter_api_token}
         )
         result = json_decode(response.body)

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,10 +90,10 @@
   </div>
 
   <!-- Group entrypoints by type -->
-  {% for entrypoint_type in entrypoint_types.values() %}
-  {% set type_name = entrypoint_type.type_name %}
-  {% set display_name = entrypoint_type.display_name %}
-  {% set description = entrypoint_type.description %}
+  {% for entrypoint_type, _ in entrypoint_types.values() %}
+  {% set type_name = entrypoint_type.get_type_name() %}
+  {% set display_name = entrypoint_type.get_display_name() %}
+  {% set description = entrypoint_type.get_description() %}
   <div class="row">
     <div class="col-xs-offset-2 col-xs-8">
       <hr>


### PR DESCRIPTION
Construction of types is deferred from app initialization to the handlers.  This is necessary because some types have dynamic content like images.  There's a lot of repeated logic in the handlers that could be cleaned up in the future.

With this change we needed to make some methods classmethods, but that's OK.  This may result in some kind of simplification/refactor in the future.

Since some filtering of entrypoint source data could be needed, with the most obvious one being by username, the username is now a parameter of the type constructor and it's possible on the Shifter example type to pass a filter to reduce the number of available choices.
